### PR TITLE
Add source references to week 1 task checklists

### DIFF
--- a/tasks/week1-client.md
+++ b/tasks/week1-client.md
@@ -1,0 +1,10 @@
+# Week 1 Client Checklist
+
+- [ ] Install project dependencies so the XMLHttpRequest-based starter template can run in Node.js.
+- [ ] Implement `fetchWithCallbacks(url, cb)` using the error-first callback convention and verify it with valid and invalid URLs.
+- [ ] Implement `fetchWithPromise(url)` that resolves or rejects based on request success and test both success and failure paths.
+- [ ] Consume the promise-based helper with async/await to confirm the asynchronous workflow behaves as expected.
+
+## Sources
+- [Week 1 Client Worksheet (PDF)](../web-advanced/subject-info/sheets/1st-week/client/week1-client-en.pdf)
+- [Callback/Promises/Async-Await demo README](../web-advanced/learning-tasks/1st-week/client/callbacks-starter-template/README.md)

--- a/tasks/week1-epics.md
+++ b/tasks/week1-epics.md
@@ -1,0 +1,11 @@
+# Week 1 Epics Checklist
+
+- [ ] Explore asynchronous patterns for making HTTP requests on the client using callbacks, promises, and async/await.
+- [ ] Design and implement a REST API for managing workout routines, covering full CRUD behaviour and validation rules.
+- [ ] Write automated tests that verify the REST specification and error handling for the workout routines service.
+
+## Sources
+- [Week 1 Client Worksheet (PDF)](../web-advanced/subject-info/sheets/1st-week/client/week1-client-en.pdf)
+- [Week 1 Server Worksheet (PDF)](../web-advanced/subject-info/sheets/1st-week/server/week1-server-en.pdf)
+- [Callback/Promises/Async-Await demo README](../web-advanced/learning-tasks/1st-week/client/callbacks-starter-template/README.md)
+- [REST spec and test exercise README](../web-advanced/learning-tasks/1st-week/server/rest-spec-and-test-exercise/rest-spec-and-test-exercise/README.md)

--- a/tasks/week1-server.md
+++ b/tasks/week1-server.md
@@ -1,0 +1,9 @@
+# Week 1 Server Checklist
+
+- [ ] Define the workout routine REST endpoints and expected behaviours in `routes/workout.js`.
+- [ ] Enforce validation rules (existing IDs, unique names, at least one exercise, correct status codes) across CRUD operations.
+- [ ] Implement automated tests in `tests/workout.test.js` that cover successful flows and the required error handling.
+
+## Sources
+- [Week 1 Server Worksheet (PDF)](../web-advanced/subject-info/sheets/1st-week/server/week1-server-en.pdf)
+- [REST spec and test exercise README](../web-advanced/learning-tasks/1st-week/server/rest-spec-and-test-exercise/rest-spec-and-test-exercise/README.md)


### PR DESCRIPTION
## Summary
- add a Week 1 checklists folder that captures epics, client, and server tasks
- append explicit Sources sections pointing to the PDFs and READMEs that inform each checklist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd1b2966988328beec6f7641560d20